### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/action.php
+++ b/action.php
@@ -23,7 +23,7 @@ class action_plugin_subconfhelper extends DokuWiki_Action_Plugin {
         'desc'   => 'override various configuration settings per subdomain',
         'url'    => 'https://www.dokuwiki.org/plugin:subconfhelper' );
   }
-  function register( &$controller) {
+  function register(Doku_Event_Handler $controller) {
     $controller->register_hook('ACTION_ACT_PREPROCESS', 'BEFORE',  $this, 'check_vhost' );
     $controller->register_hook('TPL_ACT_RENDER', 'BEFORE',  $this, 'check_act' );
   }


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
